### PR TITLE
Add compact navigation banner to Quarto lecture pages

### DIFF
--- a/Lectures/_metadata.yml
+++ b/Lectures/_metadata.yml
@@ -1,0 +1,3 @@
+format:
+  html:
+    include-before-body: lecture-banner.html

--- a/Lectures/lecture-banner.html
+++ b/Lectures/lecture-banner.html
@@ -1,0 +1,55 @@
+<div class="lecture-page-top">
+  <header class="lecture-page-header">
+    <div class="header-buttons">
+      <a href="index.html" class="header-btn">← Index</a>
+      <a href="https://github.com/AI4PhysicsNotes/2024-SuSe-HadronPhysics-Transcribe-Public" class="header-btn" target="_blank" rel="noopener noreferrer">
+        <img src="github-mark.png" alt="" aria-hidden="true" width="14" height="14">
+        GitHub
+      </a>
+      <span class="feedback-group">
+        <span class="feedback-label">Feedback:</span>
+        <a href="#" class="header-btn" id="feedback-email">Email</a>
+        <a href="#" class="header-btn" id="feedback-issue">Issue</a>
+      </span>
+    </div>
+  </header>
+  <div class="lecture-disclaimer">
+    <strong>Experimental!</strong> AI-processed lecture transcript.
+  </div>
+</div>
+<script>
+(function () {
+  var top = document.querySelector(".lecture-page-top");
+  var content = document.getElementById("quarto-content");
+  if (top && content && top.parentNode !== document.body) {
+    document.body.insertBefore(top, content);
+  }
+
+  var match = document.title.match(/\((\d{4})\)\s+Lecture\s+(\d+)/);
+  var year = match ? match[1] : "";
+  var lectureNum = match ? match[2] : "";
+  var lectureLabel = lectureNum ? "Lecture " + lectureNum : "this lecture";
+  var template = "Looking at the " + lectureLabel + ", I've noticed ";
+  var subject = lectureNum
+    ? "Feedback on Lecture " + lectureNum + (year ? " (" + year + ")" : "")
+    : "Feedback on lecture notes";
+
+  var emailLink = document.getElementById("feedback-email");
+  if (emailLink) {
+    emailLink.href =
+      "mailto:mikhail.mikhasenko@rub.de?subject=" +
+      encodeURIComponent(subject) +
+      "&body=" +
+      encodeURIComponent(template);
+  }
+
+  var issueLink = document.getElementById("feedback-issue");
+  if (issueLink) {
+    issueLink.href =
+      "https://github.com/AI4PhysicsNotes/2024-SuSe-HadronPhysics-Transcribe-Public/issues/new?title=" +
+      encodeURIComponent(subject) +
+      "&body=" +
+      encodeURIComponent(template);
+  }
+})();
+</script>

--- a/Lectures/styles.css
+++ b/Lectures/styles.css
@@ -8,9 +8,6 @@
 body {
     font-family: 'Helvetica Neue', Arial, sans-serif;
     line-height: 1.6;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 2em;
 }
 
 /* Math equations */
@@ -59,4 +56,81 @@ pre {
     padding: 1em;
     border-radius: 4px;
     overflow-x: auto;
+}
+
+/* Lecture page navigation banner (included via _metadata.yml) */
+.lecture-page-top {
+    max-width: 1200px;
+    margin: 0.5rem auto 0.75rem;
+    padding: 0 1rem;
+    box-sizing: border-box;
+}
+
+.lecture-page-header {
+    background-color: var(--rub-blue);
+    padding: 4px 8px;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+.lecture-page-header .header-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 6px;
+}
+
+.lecture-page-header .header-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    text-decoration: none;
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1.2;
+    background-color: var(--rub-green);
+    padding: 3px 8px;
+    border-radius: 3px;
+    transition: background-color 0.2s;
+    white-space: nowrap;
+}
+
+.lecture-page-header .header-btn:hover {
+    background-color: #6b8c0e;
+    color: white;
+}
+
+.lecture-page-header .header-btn img {
+    width: 14px;
+    height: 14px;
+}
+
+.lecture-page-header .feedback-group {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+}
+
+.lecture-page-header .feedback-label {
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0 2px;
+}
+
+.lecture-disclaimer {
+    text-align: center;
+    color: #666;
+    font-size: 0.72rem;
+    line-height: 1.3;
+    margin: 4px 0 0;
+    padding: 4px 8px;
+    background-color: #fff8e6;
+    border: 1px solid #ffe8a3;
+    border-radius: 3px;
 }

--- a/generate_index.py
+++ b/generate_index.py
@@ -240,9 +240,9 @@ class LectureIndexGenerator:
 <body>
     <header>
         <div class="header-buttons">
-            <a href="https://github.com/mmikhasenko/LM-Notes-HadronPhysics" target="_blank">
+            <a href="https://github.com/AI4PhysicsNotes/2024-SuSe-HadronPhysics-Transcribe-Public" target="_blank">
                 <img src="github-mark.png" alt="GitHub Logo">
-                Code
+                GitHub
             </a>
             <a href="https://moodle.ruhr-uni-bochum.de/course/view.php?id=58809" target="_blank">Moodle Course</a>
         </div>


### PR DESCRIPTION
## Summary
- Add `Lectures/_metadata.yml` and `Lectures/lecture-banner.html` so CI-rendered lecture pages include a compact top bar with:
  - Back to index
  - GitHub link (with logo)
  - Experimental AI-processed disclaimer
  - Pre-filled Email / GitHub Issue feedback links
- Extend `Lectures/styles.css` with compact banner styling that sits above the Quarto TOC grid (no sidebar overlap)
- Point the generated index page GitHub button at this public repository

## How pages are built (unchanged workflow)
CI in `.github/workflows/deploy.yml`:
1. `quarto render` each `Lectures/*.md` using `Lectures/_quarto.yml` (+ new `_metadata.yml`)
2. `python3 generate_index.py` → `Lectures/index.html`
3. Deploy `./Lectures` to `gh-pages` via peaceiris/actions-gh-pages

## Test plan
- [ ] Merge PR and confirm CI workflow succeeds on the branch
- [ ] Open a rendered lecture page on GitHub Pages and verify banner, disclaimer, and feedback links
- [ ] Confirm TOC no longer overlaps the banner
- [ ] Verify index page GitHub button links to this repo


Made with [Cursor](https://cursor.com)